### PR TITLE
Adds custom key parameter name (fixes #37)

### DIFF
--- a/README.md
+++ b/README.md
@@ -212,6 +212,17 @@ updatePerson: function (person) {
 }
 ```
 
+You can customize the name of the `.key` property by passing an option when initializing vue-firestore:
+
+```javascript
+require('firebase/firestore')
+Vue.use(VueFirestore, {key = 'id'})
+```
+
+This would allow you to do `person.id` instead of `person['.key']`.
+
+
+
 ## More Resources
 - [Quick Start on Alligator.io](https://alligator.io/vuejs/vue-cloud-firestore/)
 

--- a/src/utils/utils.js
+++ b/src/utils/utils.js
@@ -12,12 +12,13 @@ export function isObject (val) {
  * Normalize Firebase snapshot into a bindable data record.
  *
  * @param {FirebaseSnapshot} snapshot
+ * @param {string} keyName
  * @return {object}
  */
-export function normalize (snapshot) {
+export function normalize (snapshot, keyName = '.key') {
   var value = snapshot.doc ? snapshot.doc.data() : snapshot.data()
   var out = isObject(value) ? value : { '.value': value }
-  out['.key'] = snapshot.doc ? snapshot.doc.id : snapshot.id
+  out[keyName] = snapshot.doc ? snapshot.doc.id : snapshot.id
   return out
 }
 
@@ -31,3 +32,4 @@ export function ensureRefs (vm) {
     vm.$firestore = Object.create(null)
   }
 }
+


### PR DESCRIPTION
Hi,

This should do the trick regarding #37. 
The default behavior is unchanged, yet initializing with

```javascript
require('firebase/firestore')
Vue.use(VueFirestore, {key = 'id'})
```
would allow to get document's key with `doc.id` instead of `doc['.key']` which I find quite convenient.

Regards,