### PR TITLE
Javascript markdown tag added to docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -141,7 +141,7 @@ Vue firestore latest release supports binding collections as objects, you can bi
 
 The normalized resutls of `$bindCollectionAsObject`:
 
-```
+```javascript
 {
     tjlAXoQ3VAoNiJcka9: {
         firstname: "Jhon",


### PR DESCRIPTION
I noticed that the javascript object was plain text and thought it would be easier to read if it was highlighted.

Done as part of my live stream here https://youtu.be/G7rQdhJJGJk
